### PR TITLE
fixed translate3d because the argument order changed

### DIFF
--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -366,7 +366,7 @@ animation finishes to perform some action.
         dx = this.xNow - (this.containerMetrics.width / 2);
         dy = this.yNow - (this.containerMetrics.height / 2);
 
-        Polymer.Base.translate3d(this.waveContainer, dx + 'px', dy + 'px', 0);
+        Polymer.Base.translate3d(dx + 'px', dy + 'px', 0, this.waveContainer);
 
         // 2d transform for safari because of border-radius and overflow:hidden clipping bug.
         // https://bugs.webkit.org/show_bug.cgi?id=98538


### PR DESCRIPTION
The paper-ripple element is completely failing because the argument order has been switched in the utils.html file in Polymer 0.8 rc7.  There is also an error in the utils file that needs to be fixed, which I've created [a pull request for](https://github.com/Polymer/polymer/pull/1454).

I am already signed the CLA.