### PR TITLE
Fix #2 - improve target detection

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -391,7 +391,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
       <div class="button">
         <div class="center" fit>DECLINE</div>
-        <paper-rippl></paper-ripple>
+        <paper-ripple></paper-ripple>
       </div>
 
     </div>

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -558,12 +558,10 @@ Apply `circle` class to make the rippling effect within a circle.
       get target () {
         var ownerRoot = Polymer.dom(this).getOwnerRoot();
         var target;
-
-        if (ownerRoot) {
+        
+        if (this.parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
           target = ownerRoot.host;
-        }
-
-        if (!target) {
+        } else {
           target = this.parentNode;
         }
 


### PR DESCRIPTION
New logic for `target` getter:

 1. Check if `this.parentNode` is a document fragment.
 2. If it is, use `ownerRoot.host` to attach the ripple to the proper container.
 3. If it isn't, use `this.parentNode`.

The old logic would end up selecting the wrong target element as the only condition required to use `ownerRoot.host` was that `ownerRoot` existed. However, `ownerRoot` existing does not necessarily mean that `this.parentNode` is an invalid target.

Demo here: http://plnkr.co/edit/2ZlrEBCRVpe9JvxsBlcA?p=preview