### PR TITLE
Cleanup listeners on detached

### DIFF
--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -565,6 +565,11 @@ Apply `circle` class to make the rippling effect within a circle.
           this.keyEventTarget = this.target;
         }
       },
+      
+      detached: function() {
+        this.unlisten(this.target, 'up', 'upAction');
+        this.unlisten(this.target, 'down', 'downAction');
+      },
 
       get shouldKeepAnimating () {
         for (var index = 0; index < this.ripples.length; ++index) {


### PR DESCRIPTION
Each time a parent element of paper-ripple moves in the DOM it causes the paper-ripple to get more attached listeners.