### PR TITLE
fix noink on target

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "paper-styles": "polymerelements/paper-styles#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "web-component-tester": "*",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -250,6 +250,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-ripple></paper-ripple>
     </div>
 
+    <div class="button raised" noink>
+      <div class="center" fit>NO INK</div>
+      <paper-ripple noink></paper-ripple>
+    </div>
+
     <div class="button raised grey">
       <div class="center" fit>CANCEL</div>
       <paper-ripple></paper-ripple>
@@ -410,4 +415,3 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 </body>
 </html>
-

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -24,7 +24,7 @@ Example:
     </div>
 
 Note, it's important that the parent container of the ripple be relative position, otherwise
-the ripple will emanate outside of the desired container. 
+the ripple will emanate outside of the desired container.
 
 `paper-ripple` listens to "mousedown" and "mouseup" events so it would display ripple
 effect when touches on it.  You can also defeat the default behavior and
@@ -42,6 +42,15 @@ Example:
     upAction: function(e) {
       this.$.ripple.upAction();
     }
+
+If you want the ripple to not be triggereable when clicking the target element,
+you can use the `noink` attribute on the target. The ripple can still be activated
+manually by calling `ripple.simulatedRipple()`:
+
+    <div class="button raised">
+      <div class="center" fit>SUBMIT</div>
+      <paper-ripple id="ripple"></paper-ripple>
+    </div>
 
 Styling ripple effect:
 
@@ -83,7 +92,7 @@ Apply `circle` class to make the rippling effect within a circle.
   @param {Object} detail
   @param {Object} detail.node The animated node
   -->
-  
+
   <template>
     <style>
       :host {
@@ -96,23 +105,23 @@ Apply `circle` class to make the rippling effect within a circle.
         right: 0;
         bottom: 0;
       }
-  
+
       :host([animating]) {
         /* This resolves a rendering issue in Chrome (as of 40) where the
            ripple is not properly clipped by its parent (which may have
            rounded corners). See: http://jsbin.com/temexa/4
-  
+
            Note: We only apply this style conditionally. Otherwise, the browser
            will create a new compositing layer for every ripple element on the
            page, and that would be bad. */
         -webkit-transform: translate(0, 0);
         transform: translate3d(0, 0, 0);
       }
-  
+
       :host([noink]) {
         pointer-events: none;
       }
-  
+
       #background,
       #waves,
       .wave-container,
@@ -124,32 +133,32 @@ Apply `circle` class to make the rippling effect within a circle.
         width: 100%;
         height: 100%;
       }
-  
+
       #background,
       .wave {
         opacity: 0;
       }
-  
+
       #waves,
       .wave {
         overflow: hidden;
       }
-  
+
       .wave-container,
       .wave {
         border-radius: 50%;
       }
-  
+
       :host(.circle) #background,
       :host(.circle) #waves {
         border-radius: 50%;
       }
-  
+
       :host(.circle) .wave-container {
         overflow: hidden;
       }
     </style>
-    
+
     <div id="background"></div>
     <div id="waves"></div>
   </template>
@@ -565,11 +574,10 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       attached: function() {
-        this.listen(this.target, 'up', 'upAction');
-        this.listen(this.target, 'down', 'downAction');
-
         if (!this.target.hasAttribute('noink')) {
           this.keyEventTarget = this.target;
+          this.listen(this.target, 'up', 'upAction');
+          this.listen(this.target, 'down', 'downAction');
         }
       },
 

--- a/test/paper-ripple.html
+++ b/test/paper-ripple.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-ripple.html">
@@ -56,6 +57,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="NoinkTarget">
+    <template>
+      <div id="RippleContainer" noink>
+        <paper-ripple></paper-ripple>
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
     function FakeMouseEvent (target, relativeX, relativeX) {
       var rect = target.getBoundingClientRect();
@@ -69,7 +78,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     suite('<paper-ripple>', function () {
-      var mouseEvent;
       var rippleContainer;
       var ripple;
 
@@ -77,13 +85,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function () {
           rippleContainer = fixture('TrivialRipple');
           ripple = rippleContainer.firstElementChild;
-
-          mouseEvent = new FakeMouseEvent(ripple, 10, 10);
         });
 
         test('creates a ripple', function () {
           expect(ripple.ripples.length).to.be.eql(0);
-          ripple.downAction(mouseEvent);
+          MockInteractions.down(ripple);
           expect(ripple.ripples.length).to.be.eql(1);
         });
 
@@ -91,9 +97,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(ripple.ripples.length).to.be.eql(0);
 
           for (var i = 0; i < 3; ++i) {
-            ripple.downAction(mouseEvent);
+            MockInteractions.down(ripple);
             expect(ripple.ripples.length).to.be.eql(i + 1);
           }
+        });
+      });
+
+      suite('when target is noink', function () {
+        setup(function () {
+          rippleContainer = fixture('NoinkTarget');
+          ripple = rippleContainer.firstElementChild;
+        });
+
+        test('tapping does not create a ripple', function () {
+          expect(ripple.keyEventTarget).to.be.equal(ripple);
+          expect(ripple.ripples.length).to.be.eql(0);
+          MockInteractions.down(ripple);
+          expect(ripple.ripples.length).to.be.eql(0);
+        });
+
+        test('ripples can be manually created', function () {
+          expect(ripple.ripples.length).to.be.eql(0);
+          ripple.simulatedRipple()
+          expect(ripple.ripples.length).to.be.eql(1);
         });
       });
 
@@ -101,8 +127,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function () {
           rippleContainer = fixture('CenteringRipple');
           ripple = rippleContainer.firstElementChild;
-
-          mouseEvent = new FakeMouseEvent(ripple, 10, 10);
         });
 
         test('ripples will center', function (done) {
@@ -112,11 +136,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           div.style.webkitTransform = 'translate3d(0px, 0px, 0px)';
           div.style.transform = 'translate3d(0px, 0px, 0)';
 
-          ripple.downAction(mouseEvent);
+          MockInteractions.down(ripple, {x: 10, y: 10});
 
           waveContainerElement = ripple.ripples[0].waveContainer;
 
-          ripple.upAction(mouseEvent);
+          MockInteractions.up(ripple, {x: 10, y: 10});
 
           window.requestAnimationFrame(function () {
             var currentTransform = waveContainerElement.style.transform;
@@ -137,15 +161,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function () {
           rippleContainer = fixture('RecenteringRipple');
           ripple = rippleContainer.firstElementChild;
-          mouseEvent = new FakeMouseEvent(ripple, 10, 10);
         });
+        
         test('ripples will gravitate towards the center', function (done) {
           var waveContainerElement;
           var waveTranslateString;
-          ripple.downAction(mouseEvent);
+
+          MockInteractions.down(ripple, {x: 10, y: 10});
+
           waveContainerElement = ripple.ripples[0].waveContainer;
           waveTranslateString = waveContainerElement.style.transform;
-          ripple.upAction(mouseEvent);
+          MockInteractions.up(ripple, {x: 10, y: 10});
           window.requestAnimationFrame(function () {
             try {
               expect(waveTranslateString).to.be.ok;


### PR DESCRIPTION
I think the `noink` attribute wasn't implemented correctly. There is a style that applies it to the `host`, but the `attached` was changing something based on the target. In any case, using `noink` on the ripple or the target didn't have any observable effect.

I'm now living under assumption `noink` is supposed to live on the target, which I think makes sense. In this case, I've removed the listeners (so that tapping the target shows no ink), which also allows the ripple to be called manually (with `simulatedRipple`)

I've also cleaned up the tests that were manually faking events but didn't need to.