### PR TITLE
Make noink a property

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,6 +28,7 @@
     "paper-styles": "polymerelements/paper-styles#^1.0.0",
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "web-component-tester": "*",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "iron-test-helpers": "PolymerElements/iron-test-helpers#^1.0.0"
   }
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -250,6 +250,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <paper-ripple></paper-ripple>
     </div>
 
+    <div class="button raised" noink>
+      <div class="center" fit>NO INK</div>
+      <paper-ripple noink></paper-ripple>
+    </div>
+
     <div class="button raised grey">
       <div class="center" fit>CANCEL</div>
       <paper-ripple></paper-ripple>

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -584,6 +584,11 @@ Apply `circle` class to make the rippling effect within a circle.
         this.listen(this.target, 'down', 'uiDownAction');
       },
 
+      detached: function() {
+        this.unlisten(this.target, 'up', 'uiUpAction');
+        this.unlisten(this.target, 'down', 'uiDownAction');
+      },
+
       get shouldKeepAnimating () {
         for (var index = 0; index < this.ripples.length; ++index) {
           if (!this.ripples[index].isAnimationComplete) {
@@ -603,13 +608,22 @@ Apply `circle` class to make the rippling effect within a circle.
         }, 1);
       },
 
-      /** @param {Event=} event */
+      /** 
+       * Provokes a ripple down effect via a UI event, 
+       * respecting the `noink` property.
+       * @param {Event=} event 
+       */
       uiDownAction: function(event) {
         if (!this.noink) {
           this.downAction(event);
         }
       },
 
+      /** 
+       * Provokes a ripple down effect via a UI event, 
+       * *not* respecting the `noink` property.
+       * @param {Event=} event 
+       */
       downAction: function(event) {
         if (this.holdDown && this.ripples.length > 0) {
           return;
@@ -624,13 +638,22 @@ Apply `circle` class to make the rippling effect within a circle.
         }
       },
 
-      /** @param {Event=} event */
+      /** 
+       * Provokes a ripple up effect via a UI event, 
+       * respecting the `noink` property.
+       * @param {Event=} event 
+       */
       uiUpAction: function(event) {
         if (!this.noink) {
           this.upAction(event);
         }
       },
 
+      /** 
+       * Provokes a ripple up effect via a UI event, 
+       * *not* respecting the `noink` property.
+       * @param {Event=} event 
+       */
       upAction: function(event) {
         if (this.holdDown) {
           return;

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -533,6 +533,17 @@ Apply `circle` class to make the rippling effect within a circle.
           observer: '_holdDownChanged'
         },
 
+        /**
+         * If true, the ripple will not generate a ripple effect 
+         * via pointer interaction.
+         * Calling ripple's imperative api like `simulatedRipple` will 
+         * still generate the ripple effect.
+         */
+        noink: {
+          type: Boolean,
+          value: false
+        },
+
         _animating: {
           type: Boolean
         },
@@ -544,6 +555,10 @@ Apply `circle` class to make the rippling effect within a circle.
           }
         }
       },
+
+      observers: [
+        '_noinkChanged(noink, isAttached)'
+      ],
 
       get target () {
         var ownerRoot = Polymer.dom(this).getOwnerRoot();
@@ -565,12 +580,8 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       attached: function() {
-        this.listen(this.target, 'up', 'upAction');
-        this.listen(this.target, 'down', 'downAction');
-
-        if (!this.target.hasAttribute('noink')) {
-          this.keyEventTarget = this.target;
-        }
+        this.listen(this.target, 'up', 'uiUpAction');
+        this.listen(this.target, 'down', 'uiDownAction');
       },
 
       get shouldKeepAnimating () {
@@ -593,6 +604,12 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       /** @param {Event=} event */
+      uiDownAction: function(event) {
+        if (!this.noink) {
+          this.downAction(event);
+        }
+      },
+
       downAction: function(event) {
         if (this.holdDown && this.ripples.length > 0) {
           return;
@@ -608,6 +625,12 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       /** @param {Event=} event */
+      uiUpAction: function(event) {
+        if (!this.noink) {
+          this.upAction(event);
+        }
+      },
+
       upAction: function(event) {
         if (this.holdDown) {
           return;
@@ -680,27 +703,34 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       _onEnterKeydown: function() {
-        this.downAction();
-        this.async(this.upAction, 1);
+        this.uiDownAction();
+        this.async(this.uiUpAction, 1);
       },
 
       _onSpaceKeydown: function() {
-        this.downAction();
+        this.uiDownAction();
       },
 
       _onSpaceKeyup: function() {
-        this.upAction();
+        this.uiUpAction();
       },
 
+      // note: holdDown does not respect noink since it can be a focus based
+      // effect.
       _holdDownChanged: function(newVal, oldVal) {
         if (oldVal === undefined) {
           return;
         }
-
         if (newVal) {
           this.downAction();
         } else {
           this.upAction();
+        }
+      },
+
+      _noinkChanged: function(noink, attached) {
+        if (attached) {
+          this.keyEventTarget = noink ? this : this.target;
         }
       }
     });

--- a/test/paper-ripple.html
+++ b/test/paper-ripple.html
@@ -18,6 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../test-fixture/test-fixture-mocha.js"></script>
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
 
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../paper-ripple.html">
@@ -56,18 +57,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="NoinkTarget">
+    <template>
+      <div id="RippleContainer">
+        <paper-ripple noink></paper-ripple>
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
-    function FakeMouseEvent (target, relativeX, relativeX) {
-      var rect = target.getBoundingClientRect();
-
-      return {
-        detail: {
-          x: rect.left + relativeX,
-          y: rect.top + relativeX
-        }
-      };
-    }
-
     suite('<paper-ripple>', function () {
       var mouseEvent;
       var rippleContainer;
@@ -77,13 +75,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function () {
           rippleContainer = fixture('TrivialRipple');
           ripple = rippleContainer.firstElementChild;
-
-          mouseEvent = new FakeMouseEvent(ripple, 10, 10);
         });
 
         test('creates a ripple', function () {
           expect(ripple.ripples.length).to.be.eql(0);
-          ripple.downAction(mouseEvent);
+          MockInteractions.down(ripple);
           expect(ripple.ripples.length).to.be.eql(1);
         });
 
@@ -91,9 +87,29 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(ripple.ripples.length).to.be.eql(0);
 
           for (var i = 0; i < 3; ++i) {
-            ripple.downAction(mouseEvent);
+            MockInteractions.down(ripple);
             expect(ripple.ripples.length).to.be.eql(i + 1);
           }
+        });
+      });
+
+      suite('when target is noink', function () {
+        setup(function () {
+          rippleContainer = fixture('NoinkTarget');
+          ripple = rippleContainer.firstElementChild;
+        });
+
+        test('tapping does not create a ripple', function () {
+          expect(ripple.keyEventTarget).to.be.equal(ripple);
+          expect(ripple.ripples.length).to.be.eql(0);
+          MockInteractions.down(ripple);
+          expect(ripple.ripples.length).to.be.eql(0);
+        });
+
+        test('ripples can be manually created', function () {
+          expect(ripple.ripples.length).to.be.eql(0);
+          ripple.simulatedRipple()
+          expect(ripple.ripples.length).to.be.eql(1);
         });
       });
 
@@ -101,8 +117,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function () {
           rippleContainer = fixture('CenteringRipple');
           ripple = rippleContainer.firstElementChild;
-
-          mouseEvent = new FakeMouseEvent(ripple, 10, 10);
         });
 
         test('ripples will center', function (done) {
@@ -112,11 +126,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           div.style.webkitTransform = 'translate3d(0px, 0px, 0px)';
           div.style.transform = 'translate3d(0px, 0px, 0)';
 
-          ripple.downAction(mouseEvent);
+          MockInteractions.down(ripple);
 
           waveContainerElement = ripple.ripples[0].waveContainer;
 
-          ripple.upAction(mouseEvent);
+          MockInteractions.up(ripple);
 
           window.requestAnimationFrame(function () {
             var currentTransform = waveContainerElement.style.transform;
@@ -137,15 +151,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         setup(function () {
           rippleContainer = fixture('RecenteringRipple');
           ripple = rippleContainer.firstElementChild;
-          mouseEvent = new FakeMouseEvent(ripple, 10, 10);
         });
         test('ripples will gravitate towards the center', function (done) {
           var waveContainerElement;
           var waveTranslateString;
-          ripple.downAction(mouseEvent);
+          MockInteractions.down(ripple, {x: 10, y: 10});
           waveContainerElement = ripple.ripples[0].waveContainer;
           waveTranslateString = waveContainerElement.style.transform;
-          ripple.upAction(mouseEvent);
+          MockInteractions.up(ripple);
           window.requestAnimationFrame(function () {
             try {
               expect(waveTranslateString).to.be.ok;

--- a/test/paper-ripple.html
+++ b/test/paper-ripple.html
@@ -93,6 +93,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
+      suite('when holdDown is togggled', function() {
+        setup(function () {
+          rippleContainer = fixture('TrivialRipple');
+          ripple = rippleContainer.firstElementChild;
+        });
+
+        test('generates a ripple', function() {
+          ripple.holdDown = true;
+          expect(ripple.ripples.length).to.be.eql(1);
+        });
+
+        test('generates a ripple when noink', function() {
+          ripple.noink = true;
+          ripple.holdDown = true;
+          expect(ripple.ripples.length).to.be.eql(1);
+
+        });
+
+      });
+
       suite('when target is noink', function () {
         setup(function () {
           rippleContainer = fixture('NoinkTarget');
@@ -112,6 +132,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           expect(ripple.ripples.length).to.be.eql(1);
         });
       });
+
+      
 
       suite('with the `center` attribute set to true', function () {
         setup(function () {


### PR DESCRIPTION
Fixes #43. This makes `noink` a property which when set causes the element not to produce a ripple effect when it is interacted with via a pointer. The effect is still generated when the public `downAction`, `upAction`, and `simulatedRipple` effect are called. By setting `noink` on a ripple, a user can have full control over when the ripple effect is generated.