### PR TITLE
cleanup the key handlers code

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -246,27 +246,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <section>
 
     <div class="button raised">
-      <div class="center" fit>SUBMIT</div>
+      <div class="center" fit tabindex="1">SUBMIT</div>
       <paper-ripple></paper-ripple>
     </div>
 
     <div class="button raised" noink>
-      <div class="center" fit>NO INK</div>
+      <div class="center" fit tabindex="1">NO INK</div>
       <paper-ripple noink></paper-ripple>
     </div>
 
     <div class="button raised grey">
-      <div class="center" fit>CANCEL</div>
+      <div class="center" fit tabindex="1">CANCEL</div>
       <paper-ripple></paper-ripple>
     </div>
 
     <div class="button raised blue">
-      <div class="center" fit>COMPOSE</div>
+      <div class="center" fit tabindex="1">COMPOSE</div>
       <paper-ripple></paper-ripple>
     </div>
 
     <div class="button raised green">
-      <div class="center" fit>OK</div>
+      <div class="center" fit tabindex="1">OK</div>
       <paper-ripple></paper-ripple>
     </div>
 
@@ -275,17 +275,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <section>
 
     <div class="button raised grey narrow">
-      <div class="center" fit>+1</div>
+      <div class="center" fit tabindex="1">+1</div>
       <paper-ripple></paper-ripple>
     </div>
 
     <div class="button raised grey narrow label-blue">
-      <div class="center" fit>+1</div>
+      <div class="center" fit tabindex="1">+1</div>
       <paper-ripple></paper-ripple>
     </div>
 
     <div class="button raised grey narrow label-red">
-      <div class="center" fit>+1</div>
+      <div class="center" fit tabindex="1">+1</div>
       <paper-ripple></paper-ripple>
     </div>
 
@@ -294,22 +294,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <section>
 
     <div class="icon-button">
-      <iron-icon icon="menu"></iron-icon>
+      <iron-icon icon="menu" tabindex="1"></iron-icon>
       <paper-ripple class="circle" recenters></paper-ripple>
     </div>
 
     <div class="icon-button">
-      <iron-icon icon="more-vert"></iron-icon>
+      <iron-icon icon="more-vert" tabindex="1"></iron-icon>
       <paper-ripple class="circle" recenters></paper-ripple>
     </div>
 
     <div class="icon-button red">
-      <iron-icon icon="delete"></iron-icon>
+      <iron-icon icon="delete" tabindex="1"></iron-icon>
       <paper-ripple class="circle" recenters></paper-ripple>
     </div>
 
     <div class="icon-button blue">
-      <iron-icon icon="account-box"></iron-icon>
+      <iron-icon icon="account-box" tabindex="1"></iron-icon>
       <paper-ripple class="circle" recenters></paper-ripple>
     </div>
 
@@ -318,17 +318,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <section>
 
     <div class="fab red">
-      <iron-icon icon="add"></iron-icon>
+      <iron-icon icon="add" tabindex="1"></iron-icon>
       <paper-ripple class="circle" recenters></paper-ripple>
     </div>
 
     <div class="fab blue">
-      <iron-icon icon="mail"></iron-icon>
+      <iron-icon icon="mail" tabindex="1"></iron-icon>
       <paper-ripple class="circle" recenters></paper-ripple>
     </div>
 
     <div class="fab green">
-      <iron-icon icon="create"></iron-icon>
+      <iron-icon icon="create" tabindex="1"></iron-icon>
       <paper-ripple class="circle" recenters></paper-ripple>
     </div>
 
@@ -339,19 +339,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <div class="menu">
 
       <div class="item">
-        <div class="label" fit>Mark as unread</div>
+        <div class="label" fit tabindex="1">Mark as unread</div>
         <paper-ripple></paper-ripple>
       </div>
       <div class="item">
-        <div class="label" fit>Mark as important</div>
+        <div class="label" fit tabindex="1">Mark as important</div>
         <paper-ripple></paper-ripple>
       </div>
       <div class="item">
-        <div class="label" fit>Add to Tasks</div>
+        <div class="label" fit tabindex="1">Add to Tasks</div>
         <paper-ripple></paper-ripple>
       </div>
       <div class="item">
-        <div class="label" fit>Create event</div>
+        <div class="label" fit tabindex="1">Create event</div>
         <paper-ripple></paper-ripple>
       </div>
 
@@ -360,19 +360,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <div class="menu blue">
 
       <div class="item">
-        <div class="label" fit>Import</div>
+        <div class="label" fit tabindex="1">Import</div>
         <paper-ripple></paper-ripple>
       </div>
       <div class="item">
-        <div class="label" fit>Export</div>
+        <div class="label" fit tabindex="1">Export</div>
         <paper-ripple></paper-ripple>
       </div>
       <div class="item">
-        <div class="label" fit>Print</div>
+        <div class="label" fit tabindex="1">Print</div>
         <paper-ripple></paper-ripple>
       </div>
       <div class="item">
-        <div class="label" fit>Restore contacts</div>
+        <div class="label" fit tabindex="1">Restore contacts</div>
         <paper-ripple></paper-ripple>
       </div>
 
@@ -390,29 +390,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </div>
 
       <div class="button label-blue">
-        <div class="center" fit>ACCEPT</div>
+        <div class="center" fit tabindex="1">ACCEPT</div>
         <paper-ripple></paper-ripple>
       </div>
 
       <div class="button">
-        <div class="center" fit>DECLINE</div>
+        <div class="center" fit tabindex="1">DECLINE</div>
         <paper-ripple></paper-ripple>
       </div>
 
     </div>
 
-    <div class="card">
+    <div class="card" tabindex="1">
       <paper-ripple recenters></paper-ripple>
     </div>
 
-    <div class="card image">
-
+    <div class="card image" tabindex="1">
       <paper-ripple recenters></paper-ripple>
-
     </div>
 
   </section>
 
 </body>
 </html>
-

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -562,10 +562,6 @@ Apply `circle` class to make the rippling effect within a circle.
         }
       },
 
-      observers: [
-        '_noinkChanged(noink, isAttached)'
-      ],
-
       get target () {
         var ownerRoot = Polymer.dom(this).getOwnerRoot();
         var target;
@@ -586,6 +582,10 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       attached: function() {
+        // Set up a11yKeysBehavior to listen to key events on the target,
+        // so that space and enter activate the ripple even if the target doesn't
+        // handle key events. The key handlers deal with `noink` themselves.
+        this.keyEventTarget = this.target;
         this.listen(this.target, 'up', 'uiUpAction');
         this.listen(this.target, 'down', 'uiDownAction');
       },
@@ -754,12 +754,6 @@ Apply `circle` class to make the rippling effect within a circle.
           this.downAction();
         } else {
           this.upAction();
-        }
-      },
-
-      _noinkChanged: function(noink, attached) {
-        if (attached) {
-          this.keyEventTarget = noink ? this : this.target;
         }
       }
     });

--- a/test/paper-ripple.html
+++ b/test/paper-ripple.html
@@ -120,7 +120,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         test('tapping does not create a ripple', function () {
-          expect(ripple.keyEventTarget).to.be.equal(ripple);
           expect(ripple.ripples.length).to.be.eql(0);
           MockInteractions.down(ripple);
           expect(ripple.ripples.length).to.be.eql(0);
@@ -133,7 +132,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-      
+
 
       suite('with the `center` attribute set to true', function () {
         setup(function () {


### PR DESCRIPTION
When `noink` changed, the code updated who listens to `space`/`enter` (and changed it from the target to the ripple itself). This doesn't make sense, since the key handlers ignore `noink` altogether and bail early, so changing the target shouldn't affect this.

Also, I've added tabindexes to the demo so that you can tab to them.

I've tested this in `paper-checkbox` and friends, and `paper-button`/`paper-icon-button`, and it's a no-op for all (space continues to do what it used to, obviously, and with no ink, there's no ink)

/cc @sorvell who made me do this.