### PR TITLE
cleanup: remove leftover style

### DIFF
--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -115,10 +115,6 @@ Apply `circle` class to make the rippling effect within a circle.
         transform: translate3d(0, 0, 0);
       }
 
-      :host([noink]) {
-        pointer-events: none;
-      }
-
       #background,
       #waves,
       .wave-container,


### PR DESCRIPTION
Since https://github.com/PolymerElements/paper-ripple/pull/48 landed, ripple is `pointer-events:none` all the time, so this style doesn't make sense anymore.

(fixes https://github.com/PolymerElements/paper-ripple/issues/50)