### PR TITLE
update jsdoc object notation

### DIFF
--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -75,15 +75,6 @@ Apply `circle` class to make the rippling effect within a circle.
 
 <dom-module id="paper-ripple">
 
-  <!--
-  Fired when the animation finishes. This is useful if you want to wait until the ripple
-  animation finishes to perform some action.
-
-  @event transitionend
-  @param {Object} detail
-  @param {Object} detail.node The animated node
-  -->
-
   <template>
     <style>
       :host {
@@ -752,6 +743,15 @@ Apply `circle` class to make the rippling effect within a circle.
           this.upAction();
         }
       }
+
+      /**
+      Fired when the animation finishes.
+      This is useful if you want to wait until
+      the ripple animation finishes to perform some action.
+
+      @event transitionend
+      @param {{node: Object}} detail Contains the animated node.
+      */
     });
   })();
 </script>


### PR DESCRIPTION
This notation is needed since some jsdoc compilers will not accept the `.` in the param name.