### PR TITLE
Changed parent node access to use Polymer.dom api

### DIFF
--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -553,7 +553,7 @@ Apply `circle` class to make the rippling effect within a circle.
         var ownerRoot = Polymer.dom(this).getOwnerRoot();
         var target;
 
-        if (this.parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
+        if (Polymer.dom(this).parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
           target = ownerRoot.host;
         } else {
           target = this.parentNode;


### PR DESCRIPTION
When adding a `<paper-ripple>` dynamically using React in the render method (i.e.)
```
let component = React.createClass({
getInitialState: function() {
 return {addIt: false}
}
render: function() {
let node = null;
if (this.state.addIt) {
  node = <paper-ripple/>
}
return <div>{node}</div>
}
componentDidMount: function () {
   this.setState({addIt: true})
}

})
```

[This line] (https://github.com/PolymerElements/paper-ripple/blob/master/paper-ripple.html#L556) gives me an error because `this.parentNode` is undefined.

[Per these specifications](https://www.polymer-project.org/1.0/docs/devguide/local-dom.html#dom-api) I believe a better alternative is to use the `Polymer.dom` api.