### PR TITLE
Cache whether the parent node type is a fragment node

### DIFF
--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -554,7 +554,7 @@ Apply `circle` class to make the rippling effect within a circle.
         var ownerRoot = Polymer.dom(this).getOwnerRoot();
         var target;
 
-        if (this.parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
+        if (this.isChildOfFragmentNode) {
           target = ownerRoot.host;
         } else {
           target = this.parentNode;
@@ -574,6 +574,8 @@ Apply `circle` class to make the rippling effect within a circle.
         // so that space and enter activate the ripple even if the target doesn't
         // handle key events. The key handlers deal with `noink` themselves.
         this.keyEventTarget = this.target;
+        // Type 11 is a DOCUMENT_FRAGMENT_NODE.
+        this.isChildOfFragmentNode = this.parentNode.nodeType == 11;
         this.listen(this.target, 'up', 'uiUpAction');
         this.listen(this.target, 'down', 'uiDownAction');
       },

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -574,7 +574,6 @@ Apply `circle` class to make the rippling effect within a circle.
         // so that space and enter activate the ripple even if the target doesn't
         // handle key events. The key handlers deal with `noink` themselves.
         this.keyEventTarget = this.target;
-        // Type 11 is a DOCUMENT_FRAGMENT_NODE.
         this.savedParentNode = this.parentNode;
         this.listen(this.target, 'up', 'uiUpAction');
         this.listen(this.target, 'down', 'uiDownAction');

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -554,10 +554,10 @@ Apply `circle` class to make the rippling effect within a circle.
         var ownerRoot = Polymer.dom(this).getOwnerRoot();
         var target;
 
-        if (this.isChildOfFragmentNode) {
+        if (this.savedParentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
           target = ownerRoot.host;
         } else {
-          target = this.parentNode;
+          target = this.savedParentNode;
         }
 
         return target;
@@ -575,7 +575,7 @@ Apply `circle` class to make the rippling effect within a circle.
         // handle key events. The key handlers deal with `noink` themselves.
         this.keyEventTarget = this.target;
         // Type 11 is a DOCUMENT_FRAGMENT_NODE.
-        this.isChildOfFragmentNode = this.parentNode.nodeType == 11;
+        this.savedParentNode = this.parentNode;
         this.listen(this.target, 'up', 'uiUpAction');
         this.listen(this.target, 'down', 'uiDownAction');
       },

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -551,16 +551,7 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       get target () {
-        var ownerRoot = Polymer.dom(this).getOwnerRoot();
-        var target;
-
-        if (this.savedParentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
-          target = ownerRoot.host;
-        } else {
-          target = this.savedParentNode;
-        }
-
-        return target;
+        return this.keyEventTarget;
       },
 
       keyBindings: {
@@ -573,16 +564,19 @@ Apply `circle` class to make the rippling effect within a circle.
         // Set up a11yKeysBehavior to listen to key events on the target,
         // so that space and enter activate the ripple even if the target doesn't
         // handle key events. The key handlers deal with `noink` themselves.
-        this.keyEventTarget = this.target;
-        this.savedParentNode = this.parentNode;
-        this.listen(this.target, 'up', 'uiUpAction');
-        this.listen(this.target, 'down', 'uiDownAction');
+        if (this.parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
+          this.keyEventTarget = Polymer.dom(this).getOwnerRoot().host;
+        } else {
+          this.keyEventTarget = this.parentNode;
+        }
+        this.listen(this.keyEventTarget, 'up', 'uiUpAction');
+        this.listen(this.keyEventTarget, 'down', 'uiDownAction');
       },
 
       detached: function() {
-        this.unlisten(this.target, 'up', 'uiUpAction');
-        this.unlisten(this.target, 'down', 'uiDownAction');
-        this.savedParentNode = null;
+        this.unlisten(this.keyEventTarget, 'up', 'uiUpAction');
+        this.unlisten(this.keyEventTarget, 'down', 'uiDownAction');
+        this.keyEventTarget = null;
       },
 
       get shouldKeepAnimating () {
@@ -630,6 +624,7 @@ Apply `circle` class to make the rippling effect within a circle.
         ripple.downAction(event);
 
         if (!this._animating) {
+          this._animating = true;
           this.animate();
         }
       },
@@ -659,6 +654,7 @@ Apply `circle` class to make the rippling effect within a circle.
           ripple.upAction(event);
         });
 
+        this._animating = true;
         this.animate();
       },
 
@@ -697,10 +693,11 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       animate: function() {
+        if (!this._animating) {
+          return;
+        }
         var index;
         var ripple;
-
-        this._animating = true;
 
         for (index = 0; index < this.ripples.length; ++index) {
           ripple = this.ripples[index];

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -582,6 +582,7 @@ Apply `circle` class to make the rippling effect within a circle.
       detached: function() {
         this.unlisten(this.target, 'up', 'uiUpAction');
         this.unlisten(this.target, 'down', 'uiDownAction');
+        this.savedParentNode = null;
       },
 
       get shouldKeepAnimating () {


### PR DESCRIPTION
Use the keyEventTarget rather than the parentNode to prevent exception during detached() due to parentNode being null in this.target. Also separating this._animating from the animate() to avoid transitionend events. 