### PR TITLE
Fix for removing paper-ripple elements.

### DIFF
--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -555,28 +555,23 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       keyBindings: {
+        'down': 'uiDownAction',
         'enter:keydown': '_onEnterKeydown',
         'space:keydown': '_onSpaceKeydown',
-        'space:keyup': '_onSpaceKeyup'
+        'space:keyup': '_onSpaceKeyup',
+        'up': 'uiUpAction'
       },
 
       attached: function() {
         // Set up a11yKeysBehavior to listen to key events on the target,
-        // so that space and enter activate the ripple even if the target doesn't
-        // handle key events. The key handlers deal with `noink` themselves.
+        // so that space and enter activate the ripple even if the target
+        // doesn't handle key events. The key handlers deal with `noink`
+        // themselves.
         if (this.parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
           this.keyEventTarget = Polymer.dom(this).getOwnerRoot().host;
         } else {
           this.keyEventTarget = this.parentNode;
         }
-        this.listen(this.keyEventTarget, 'up', 'uiUpAction');
-        this.listen(this.keyEventTarget, 'down', 'uiDownAction');
-      },
-
-      detached: function() {
-        this.unlisten(this.keyEventTarget, 'up', 'uiUpAction');
-        this.unlisten(this.keyEventTarget, 'down', 'uiDownAction');
-        this.keyEventTarget = null;
       },
 
       get shouldKeepAnimating () {

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -555,23 +555,28 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       keyBindings: {
-        'down': 'uiDownAction',
         'enter:keydown': '_onEnterKeydown',
         'space:keydown': '_onSpaceKeydown',
-        'space:keyup': '_onSpaceKeyup',
-        'up': 'uiUpAction'
+        'space:keyup': '_onSpaceKeyup'
       },
 
       attached: function() {
         // Set up a11yKeysBehavior to listen to key events on the target,
-        // so that space and enter activate the ripple even if the target
-        // doesn't handle key events. The key handlers deal with `noink`
-        // themselves.
+        // so that space and enter activate the ripple even if the target doesn't
+        // handle key events. The key handlers deal with `noink` themselves.
         if (this.parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
           this.keyEventTarget = Polymer.dom(this).getOwnerRoot().host;
         } else {
           this.keyEventTarget = this.parentNode;
         }
+        this.listen(this.keyEventTarget, 'up', 'uiUpAction');
+        this.listen(this.keyEventTarget, 'down', 'uiDownAction');
+      },
+
+      detached: function() {
+        this.unlisten(this.keyEventTarget, 'up', 'uiUpAction');
+        this.unlisten(this.keyEventTarget, 'down', 'uiDownAction');
+        this.keyEventTarget = null;
       },
 
       get shouldKeepAnimating () {

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -551,16 +551,7 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       get target () {
-        var ownerRoot = Polymer.dom(this).getOwnerRoot();
-        var target;
-
-        if (this.parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
-          target = ownerRoot.host;
-        } else {
-          target = this.parentNode;
-        }
-
-        return target;
+        return this.keyEventTarget;
       },
 
       keyBindings: {
@@ -573,14 +564,19 @@ Apply `circle` class to make the rippling effect within a circle.
         // Set up a11yKeysBehavior to listen to key events on the target,
         // so that space and enter activate the ripple even if the target doesn't
         // handle key events. The key handlers deal with `noink` themselves.
-        this.keyEventTarget = this.target;
-        this.listen(this.target, 'up', 'uiUpAction');
-        this.listen(this.target, 'down', 'uiDownAction');
+        if (this.parentNode.nodeType == 11) { // DOCUMENT_FRAGMENT_NODE
+          this.keyEventTarget = Polymer.dom(this).getOwnerRoot().host;
+        } else {
+          this.keyEventTarget = this.parentNode;
+        }
+        this.listen(this.keyEventTarget, 'up', 'uiUpAction');
+        this.listen(this.keyEventTarget, 'down', 'uiDownAction');
       },
 
       detached: function() {
-        this.unlisten(this.target, 'up', 'uiUpAction');
-        this.unlisten(this.target, 'down', 'uiDownAction');
+        this.unlisten(this.keyEventTarget, 'up', 'uiUpAction');
+        this.unlisten(this.keyEventTarget, 'down', 'uiDownAction');
+        this.keyEventTarget = null;
       },
 
       get shouldKeepAnimating () {
@@ -628,6 +624,7 @@ Apply `circle` class to make the rippling effect within a circle.
         ripple.downAction(event);
 
         if (!this._animating) {
+          this._animating = true;
           this.animate();
         }
       },
@@ -657,6 +654,7 @@ Apply `circle` class to make the rippling effect within a circle.
           ripple.upAction(event);
         });
 
+        this._animating = true;
         this.animate();
       },
 
@@ -695,10 +693,11 @@ Apply `circle` class to make the rippling effect within a circle.
       },
 
       animate: function() {
+        if (!this._animating) {
+          return;
+        }
         var index;
         var ripple;
-
-        this._animating = true;
 
         for (index = 0; index < this.ripples.length; ++index) {
           ripple = this.ripples[index];

--- a/test/paper-ripple.html
+++ b/test/paper-ripple.html
@@ -63,6 +63,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </template>
   </test-fixture>
 
+  <test-fixture id="NoRipple">
+    <template>
+      <div id="RippleContainer">
+      </div>
+    </template>
+  </test-fixture>
+
   <script>
     suite('<paper-ripple>', function () {
       var mouseEvent;
@@ -130,8 +137,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
       });
 
-
-
       suite('with the `center` attribute set to true', function () {
         setup(function () {
           rippleContainer = fixture('CenteringRipple');
@@ -188,6 +193,42 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               done(e);
             }
           });
+        });
+      });
+
+      suite('remove a paper ripple', function () {
+        setup(function () {
+          rippleContainer = fixture('NoRipple');
+        });
+        test('add and remove a paper-ripple', function (done) {
+          var ripple = document.createElement('paper-ripple');
+          ripple.addEventListener('transitionend', function() {
+            expect(ripple.parentNode).to.be.ok;
+            Polymer.dom(rippleContainer).removeChild(ripple);
+            done();
+          });
+          Polymer.dom(rippleContainer).appendChild(ripple);
+          ripple.downAction();
+          ripple.upAction();
+        });
+      });
+
+      suite('avoid double transitionend event', function () {
+        setup(function () {
+          rippleContainer = fixture('NoRipple');
+        });
+        test('the transitionend event should only fire once', function (done) {
+          var ripple = document.createElement('paper-ripple');
+          var transitionedEventCount = 0;
+          ripple.addEventListener('transitionend', function() {
+            ++transitionedEventCount;
+            expect(transitionedEventCount).to.be.eql(1);
+            Polymer.dom(rippleContainer).removeChild(ripple);
+            setTimeout(function() { done(); });
+          });
+          Polymer.dom(rippleContainer).appendChild(ripple);
+          ripple.downAction();
+          ripple.upAction();
         });
       });
 


### PR DESCRIPTION
Use the keyEventTarget rather than the parentNode to prevent exception during detached() due to parentNode being null in this.target. Also separating this._animating from the animate() to avoid extraneous transitioned events.

Fixes #45, fixes #39