### PR TITLE
iron-a11y-keys-behavior v1.1.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   },
   "main": "paper-ripple.html",
   "dependencies": {
-    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.0.0",
+    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.1.4",
     "polymer": "Polymer/polymer#^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #82. In `iron-a11y-keys-behavior v1.1.4` `keyEventTarget = null` is correctly handled.