### PR TITLE
Check keyEventTarget for null

### DIFF
--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -569,10 +569,9 @@ Apply `circle` class to make the rippling effect within a circle.
         } else {
           this.keyEventTarget = this.parentNode;
         }
-        if (this.keyEventTarget !== null) {
-          this.listen(this.keyEventTarget, 'up', 'uiUpAction');
-          this.listen(this.keyEventTarget, 'down', 'uiDownAction');
-        }
+        var keyEventTarget = /** @type {!EventTarget} */ (this.keyEventTarget);
+        this.listen(keyEventTarget, 'up', 'uiUpAction');
+        this.listen(keyEventTarget, 'down', 'uiDownAction');
       },
 
       detached: function() {

--- a/paper-ripple.html
+++ b/paper-ripple.html
@@ -569,8 +569,10 @@ Apply `circle` class to make the rippling effect within a circle.
         } else {
           this.keyEventTarget = this.parentNode;
         }
-        this.listen(this.keyEventTarget, 'up', 'uiUpAction');
-        this.listen(this.keyEventTarget, 'down', 'uiDownAction');
+        if (this.keyEventTarget !== null) {
+          this.listen(this.keyEventTarget, 'up', 'uiUpAction');
+          this.listen(this.keyEventTarget, 'down', 'uiDownAction');
+        }
       },
 
       detached: function() {


### PR DESCRIPTION
Check keyEventTarget for null prior to calling listen().
This fixes a closure compiler issue with type of keyEventTarget
and the acceptable parameters to listen().