### PR TITLE
reusable paper-ripple

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   },
   "main": "paper-ripple.html",
   "dependencies": {
-    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.1.4",
+    "iron-a11y-keys-behavior": "polymerelements/iron-a11y-keys-behavior#^1.1.5",
     "polymer": "Polymer/polymer#^1.1.0"
   },
   "devDependencies": {

--- a/test/paper-ripple.html
+++ b/test/paper-ripple.html
@@ -211,6 +211,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           ripple.downAction();
           ripple.upAction();
         });
+        test('reuse a paper-ripple', function (done) {
+          var ripple = document.createElement('paper-ripple');
+          Polymer.dom(rippleContainer).appendChild(ripple);
+          Polymer.dom(rippleContainer).removeChild(ripple);
+          
+          ripple.addEventListener('transitionend', function() {
+            expect(ripple.parentNode).to.be.ok;
+            Polymer.dom(document.body).removeChild(ripple);
+            done();
+          });
+          Polymer.dom(document.body).appendChild(ripple);
+          ripple.downAction();
+          ripple.upAction();
+        });
       });
 
       suite('avoid double transitionend event', function () {


### PR DESCRIPTION
Fixes #82, and now makes sure about it with a test!
Previously, https://github.com/PolymerElements/paper-ripple/pull/85 updated only bower.json, without adding any test (as the issue was on another component). This time we make sure `paper-ripple` can be safely appended/removed/appended again with a unit test.