### PR TITLE
Add PaperRipple.rippleAnimate() as an alias for animate().

### DIFF
--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,5 @@
+{
+  "excludeIdentifiers": [
+    "animate"
+  ]
+}

--- a/paper-ripple.js
+++ b/paper-ripple.js
@@ -658,7 +658,7 @@ Polymer({
   },
 
   /**
-   * This conflicts with Element#antimate().
+   * This conflicts with Element#animate().
    * https://developer.mozilla.org/en-US/docs/Web/API/Element/animate
    * @suppress {checkTypes}
    */
@@ -686,6 +686,14 @@ Polymer({
     } else {
       window.requestAnimationFrame(this._boundAnimate);
     }
+  },
+
+  /**
+   * An alias for animate() whose name does not conflict with the platform
+   * Element.animate() method.
+   */
+  animateRipple: function() {
+    return this.animate();
   },
 
   _onEnterKeydown: function() {

--- a/paper-ripple.js
+++ b/paper-ripple.js
@@ -658,8 +658,11 @@ Polymer({
   },
 
   /**
-   * This conflicts with Element#animate().
-   * https://developer.mozilla.org/en-US/docs/Web/API/Element/animate
+   * Deprecated. Please use animateRipple() instead.
+   *
+   * This method name conflicts with Element#animate().
+   * https://developer.mozilla.org/en-US/docs/Web/API/Element/animate.
+   *
    * @suppress {checkTypes}
    */
   animate: function() {


### PR DESCRIPTION
Also don't emit the `animate()` method in the TypeScript types, because it conflicts with `Element.animate()`.

This way the types compile, but there is still a way for users to type-safely call our `animate()` method.